### PR TITLE
bug: removed curl command condition (PPS-522)

### DIFF
--- a/espay/client.go
+++ b/espay/client.go
@@ -106,13 +106,11 @@ func (c *EspayClient) ExecuteRequest(req *http.Request) ([]byte, error) {
 	c.Logger.Info("Start requesting: %v ", req.URL)
 	res, err := c.getHTTPClient().Do(req)
 	if err != nil {
-		c.Logger.Error("Request failed. Error : %v , Curl Request : %v", err, command)
+		c.Logger.Error("Request failed. HTTP Status Code : %d | Error : %v , Curl Request : %v", res.StatusCode, err, command)
 		return nil, err
 	}
 
-	if !c.IsProduction {
-		c.Logger.Info("Curl Request: %v ", command)
-	}
+	c.Logger.Info("Curl Request: ", command)
 
 	defer res.Body.Close()
 	c.Logger.Info("Completed in %v", time.Since(start))


### PR DESCRIPTION
## What does this PR do?
Removed curl command condition when flag is production is enabled. This cause headachae when we want tot race issue when response http is 200 but request cannot go through

## Why are we doing this? Any context or related work?
https://kitabisa.atlassian.net/browse/PPS-522

## Where should a reviewer start?
_optional -- if your changes affected so much files, it is encouraged to give helper for reviewer_

## Screenshots
_optional -- You may put the database, sequence or any diagram needed_

## Manual testing steps?
_Steps to do tests. including all possible that can hape_

## Database changes
_optional -- If there's database changes, put it here_

## Config changes
_optional -- If there's config changes, put it here_

## Deployment instructions
_optional -- Better to put it if there's some 'special case' for deployment_
